### PR TITLE
Fix: sum over classes before reduction in multi_class_focal_loss

### DIFF
--- a/focal_loss.py
+++ b/focal_loss.py
@@ -102,6 +102,7 @@ class FocalLoss(nn.Module):
 
         # Apply focal loss weight
         loss = focal_weight.unsqueeze(1) * ce_loss
+        loss = loss.sum(dim=1)
 
         if self.reduction == 'mean':
             return loss.mean()


### PR DESCRIPTION
There is a dimensional reduction bug in the `multi_class_focal_loss` implementation. The code currently computes the loss as a matrix of shape `[batch_size, num_classes]` and directly applies `loss.mean()`. This dilutes the final loss value by a factor of `num_classes`, making the returned loss exponentially smaller than it should be.